### PR TITLE
feat: add Homebrew tap with GitHub App authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,15 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
 
+      - name: Generate GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: orbiqd
+          repositories: homebrew-briefkit
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -28,3 +37,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAP_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -81,3 +81,20 @@ release:
     name: orbiqd-briefkit
   draft: false
   prerelease: auto
+
+brews:
+  - name: briefkit
+    repository:
+      owner: orbiqd
+      name: homebrew-briefkit
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+    directory: Formula
+    homepage: "https://github.com/orbiqd/orbiqd-briefkit"
+    description: "Local orchestration tool for subscription-based coding CLIs"
+    license: MIT
+    install: |
+      bin.install "briefkit-ctl"
+      bin.install "briefkit-mcp"
+      bin.install "briefkit-runner"
+    test: |
+      system "#{bin}/briefkit-ctl", "--version"

--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ BriefKit consists of three components:
   - [Codex](https://codex.anthropic.com) (`codex` binary)
   - [Gemini](https://ai.google.dev) (`gemini` binary)
 
+### Homebrew (macOS)
+
+```bash
+brew tap orbiqd/briefkit
+brew install briefkit
+```
+
+This installs prebuilt binaries for macOS (arm64 and amd64). No local compilation required.
+
 ### Build from Source
 
 ```bash


### PR DESCRIPTION
## Related issue

Closes #5

## Summary

- Add `brews` configuration to `.goreleaser.yaml` for auto-generating Homebrew formula
- Update release workflow to generate GitHub App token for cross-repo push to `homebrew-briefkit`
- Document Homebrew installation in README

### Prerequisites (manual steps required before merge)

1. Create GitHub App `briefkit-release-bot` with Contents read/write permission
2. Install the App on `homebrew-briefkit` repository
3. Add secrets to this repo:
   - `APP_ID` - GitHub App ID
   - `APP_PRIVATE_KEY` - Private key from the App

See plan in issue #5 for detailed instructions.