### PR TITLE
Add make setup target for local development

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -31,7 +31,13 @@ Follow these steps to get the project running on your local machine.
     make build-local
     ```
 
-4.  **Run the application:**
+4.  **Setup local agent configuration (optional):**
+    Build and configure all detected runtimes using locally built binaries. This overwrites existing configs.
+    ```bash
+    make setup
+    ```
+
+5.  **Run the application:**
     Execute the compiled binary.
     ```bash
     ./bin/briefkit-ctl

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-local build-release build-all build-mocks lint lint-go lint-goreleaser test clean run-briefkit-runner debug-briefkit-mcp
+.PHONY: build build-local build-release build-all build-mocks lint lint-go lint-goreleaser test clean run-briefkit-runner debug-briefkit-mcp setup
 
 # Local build (current platform via go build)
 build: build-local
@@ -46,6 +46,9 @@ run-briefkit-runner: build-local
 
 debug-briefkit-mcp: build-local
 	DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector ./bin/briefkit-mcp
+
+setup: build
+	./bin/briefkit-ctl setup --force
 
 # Clean
 clean:


### PR DESCRIPTION
## Related issue

Closes #N/A

## Summary
- Add a `make setup` target that builds and runs local setup with `--force`
- Document the local setup workflow in DEVELOPMENT.md
