### PR TITLE
fix(cli): preserve symlink path in ResolveExecutable

### DIFF
--- a/internal/pkg/cli/dirs.go
+++ b/internal/pkg/cli/dirs.go
@@ -14,6 +14,8 @@ import (
 
 var ErrExecutableNotFound = errors.New("executable not found")
 
+var osExecutable = os.Executable
+
 const (
 	ExecutableCtl    = "briefkit-ctl"
 	ExecutableMCP    = "briefkit-mcp"
@@ -49,17 +51,12 @@ func ResolveExecutable(ctx context.Context, executableName string) (string, erro
 		return envPath, nil
 	}
 
-	execPath, err := os.Executable()
+	execPath, err := osExecutable()
 	if err != nil {
 		return "", fmt.Errorf("get executable path: %w", err)
 	}
 
-	evalPath, err := filepath.EvalSymlinks(execPath)
-	if err != nil {
-		return "", fmt.Errorf("eval symlinks: %w", err)
-	}
-
-	execDir := filepath.Dir(evalPath)
+	execDir := filepath.Dir(execPath)
 	executablePath := filepath.Join(execDir, executableName)
 
 	if _, err := os.Stat(executablePath); err == nil {

--- a/internal/pkg/cli/dirs_test.go
+++ b/internal/pkg/cli/dirs_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -50,4 +51,37 @@ func TestResolveRuntimeLogDir_RelativePath_ReturnsAbsolute(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.True(t, filepath.IsAbs(dir), "expected absolute path, got: %s", dir)
+}
+
+func TestResolveExecutable_WhenCalledViaSymlink_ThenPreservesSymlinkPath(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	realDir := filepath.Join(tmpDir, "real")
+	symlinkDir := filepath.Join(tmpDir, "symlink")
+
+	require.NoError(t, os.MkdirAll(realDir, 0o750))
+
+	realExecutable := filepath.Join(realDir, "briefkit-ctl")
+	targetExecutable := filepath.Join(realDir, ExecutableMCP)
+
+	require.NoError(t, os.WriteFile(realExecutable, []byte("#!/bin/sh\necho test"), 0o600))
+	require.NoError(t, os.WriteFile(targetExecutable, []byte("#!/bin/sh\necho mcp"), 0o600))
+
+	require.NoError(t, os.Symlink(realDir, symlinkDir))
+
+	symlinkExecutable := filepath.Join(symlinkDir, "briefkit-ctl")
+
+	originalOsExecutable := osExecutable
+	osExecutable = func() (string, error) {
+		return symlinkExecutable, nil
+	}
+	t.Cleanup(func() {
+		osExecutable = originalOsExecutable
+	})
+
+	result, err := ResolveExecutable(context.Background(), ExecutableMCP)
+
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(symlinkDir, ExecutableMCP), result,
+		"should return path using symlink directory, not resolved real path")
 }


### PR DESCRIPTION
## Related issue
Closes #26

## Summary
Remove `filepath.EvalSymlinks()` call in `ResolveExecutable` to preserve Homebrew symlink paths. This prevents MCP server configuration from breaking after `brew upgrade`.