### PR TITLE
feat(workspace): add cwd:// provider for current working directory

### DIFF
--- a/internal/pkg/cli/workspace.go
+++ b/internal/pkg/cli/workspace.go
@@ -2,12 +2,14 @@ package cli
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/afero"
 
 	"github.com/orbiqd/orbiqd-briefkit/internal/pkg/workspace"
+	"github.com/orbiqd/orbiqd-briefkit/internal/pkg/workspace/cwd"
 	"github.com/orbiqd/orbiqd-briefkit/internal/pkg/workspace/dir"
 	"github.com/orbiqd/orbiqd-briefkit/internal/pkg/workspace/git"
 )
@@ -30,9 +32,11 @@ func CreateWorkspaceManagerFromConfig(config StoreConfig) (*workspace.Manager, e
 	fs := afero.NewOsFs()
 
 	dirProvider := dir.NewProvider(fs, runsPath)
+	cwdProvider := cwd.NewProvider(fs, runsPath, os.Getwd)
 
 	providers := map[string]workspace.Provider{
 		"dir": dirProvider,
+		"cwd": cwdProvider,
 	}
 
 	if gitProvider, err := git.NewProviderWithDefaults(runsPath); err == nil {

--- a/internal/pkg/workspace/cwd/provider.go
+++ b/internal/pkg/workspace/cwd/provider.go
@@ -1,0 +1,89 @@
+package cwd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+
+	aferocopy "go.nhat.io/aferocopy/v2"
+
+	"github.com/google/uuid"
+	"github.com/spf13/afero"
+
+	"github.com/orbiqd/orbiqd-briefkit/internal/pkg/workspace"
+)
+
+// Provider provisions isolated workspace copies from the current working directory.
+// The scheme for this provider is "cwd" (e.g. cwd://).
+type Provider struct {
+	fs       afero.Fs
+	runsPath string
+	getwd    func() (string, error)
+}
+
+// NewProvider creates a Provider that stores per-execution copies under runsPath.
+// getwd is called on each Provision to resolve the current working directory.
+func NewProvider(fs afero.Fs, runsPath string, getwd func() (string, error)) *Provider {
+	return &Provider{fs: fs, runsPath: runsPath, getwd: getwd}
+}
+
+// Provision copies the current working directory into a fresh per-execution directory.
+// Returns ErrResolveCwd when the current working directory cannot be determined.
+func (p *Provider) Provision(ctx context.Context, _ url.URL) (workspace.ProvisionResult, error) {
+	srcPath, err := p.getwd()
+	if err != nil {
+		return workspace.ProvisionResult{}, fmt.Errorf("%w: %w", ErrResolveCwd, err)
+	}
+
+	if !filepath.IsAbs(srcPath) {
+		return workspace.ProvisionResult{}, fmt.Errorf("%w: path must be absolute", ErrResolveCwd)
+	}
+
+	info, err := p.fs.Stat(srcPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return workspace.ProvisionResult{}, ErrSourceNotFound
+		}
+		return workspace.ProvisionResult{}, fmt.Errorf("stat cwd: %w", err)
+	}
+
+	if !info.IsDir() {
+		return workspace.ProvisionResult{}, ErrSourceNotDirectory
+	}
+
+	runDir := filepath.Join(p.runsPath, uuid.NewString())
+	if err := p.fs.MkdirAll(runDir, 0o755); err != nil {
+		return workspace.ProvisionResult{}, fmt.Errorf("create run directory: %w", err)
+	}
+
+	if err := aferocopy.Copy(srcPath, runDir, aferocopy.Options{
+		SrcFs:  p.fs,
+		DestFs: p.fs,
+		OnSymlink: func(_ afero.Fs, _ string) aferocopy.SymlinkAction {
+			return aferocopy.Shallow
+		},
+	}); err != nil {
+		_ = p.fs.RemoveAll(runDir)
+		return workspace.ProvisionResult{}, fmt.Errorf("copy workspace: %w", err)
+	}
+
+	cleanup := func() error {
+		return p.fs.RemoveAll(runDir)
+	}
+
+	return workspace.ProvisionResult{WorkDir: runDir, Cleanup: cleanup}, nil
+}
+
+var (
+	// ErrResolveCwd indicates the current working directory could not be determined.
+	ErrResolveCwd = errors.New("workspace cwd resolution failed")
+
+	// ErrSourceNotFound indicates the current working directory does not exist on the filesystem.
+	ErrSourceNotFound = errors.New("workspace source not found")
+
+	// ErrSourceNotDirectory indicates the current working directory path is not a directory.
+	ErrSourceNotDirectory = errors.New("workspace source is not a directory")
+)

--- a/internal/pkg/workspace/cwd/provider_test.go
+++ b/internal/pkg/workspace/cwd/provider_test.go
@@ -1,0 +1,186 @@
+package cwd
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// errStatFs wraps afero.Fs and overrides Stat to always return the given error.
+type errStatFs struct {
+	afero.Fs
+	err error
+}
+
+func (f *errStatFs) Stat(_ string) (os.FileInfo, error) {
+	return nil, f.err
+}
+
+// errMkdirAllFs wraps afero.Fs and overrides MkdirAll to always return the given error.
+type errMkdirAllFs struct {
+	afero.Fs
+	err error
+}
+
+func (f *errMkdirAllFs) MkdirAll(_ string, _ os.FileMode) error {
+	return f.err
+}
+
+// errWriteFs wraps afero.Fs and makes Create/OpenFile fail for paths under the given prefix.
+type errWriteFs struct {
+	afero.Fs
+	prefix string
+	err    error
+}
+
+func (f *errWriteFs) Create(name string) (afero.File, error) {
+	if strings.HasPrefix(name, f.prefix) {
+		return nil, f.err
+	}
+	return f.Fs.Create(name)
+}
+
+func (f *errWriteFs) OpenFile(name string, flag int, perm os.FileMode) (afero.File, error) {
+	if strings.HasPrefix(name, f.prefix) && flag != os.O_RDONLY {
+		return nil, f.err
+	}
+	return f.Fs.OpenFile(name, flag, perm)
+}
+
+func TestProvider_Provision_WhenGetwdFails_ThenReturnsErrResolveCwd(t *testing.T) {
+	getwdErr := errors.New("getwd failed")
+	provider := NewProvider(afero.NewMemMapFs(), "/runs", func() (string, error) {
+		return "", getwdErr
+	})
+
+	_, err := provider.Provision(context.Background(), url.URL{Scheme: "cwd"})
+
+	require.ErrorIs(t, err, ErrResolveCwd)
+	require.ErrorIs(t, err, getwdErr)
+}
+
+func TestProvider_Provision_WhenCwdNotAbsolute_ThenReturnsErrResolveCwd(t *testing.T) {
+	provider := NewProvider(afero.NewMemMapFs(), "/runs", func() (string, error) {
+		return "relative/path", nil
+	})
+
+	_, err := provider.Provision(context.Background(), url.URL{Scheme: "cwd"})
+
+	require.ErrorIs(t, err, ErrResolveCwd)
+}
+
+func TestProvider_Provision_WhenCwdNotFound_ThenReturnsErrSourceNotFound(t *testing.T) {
+	provider := NewProvider(afero.NewMemMapFs(), "/runs", func() (string, error) {
+		return "/nonexistent", nil
+	})
+
+	_, err := provider.Provision(context.Background(), url.URL{Scheme: "cwd"})
+
+	require.ErrorIs(t, err, ErrSourceNotFound)
+}
+
+func TestProvider_Provision_WhenCwdNotDirectory_ThenReturnsErrSourceNotDirectory(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/src/file.txt", []byte("data"), 0644))
+	provider := NewProvider(fs, "/runs", func() (string, error) {
+		return "/src/file.txt", nil
+	})
+
+	_, err := provider.Provision(context.Background(), url.URL{Scheme: "cwd"})
+
+	require.ErrorIs(t, err, ErrSourceNotDirectory)
+}
+
+func TestProvider_Provision_WhenStatFails_ThenReturnsError(t *testing.T) {
+	statErr := errors.New("permission denied")
+	fs := &errStatFs{Fs: afero.NewMemMapFs(), err: statErr}
+	provider := NewProvider(fs, "/runs", func() (string, error) {
+		return "/src", nil
+	})
+
+	_, err := provider.Provision(context.Background(), url.URL{Scheme: "cwd"})
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, statErr)
+}
+
+func TestProvider_Provision_WhenMkdirFails_ThenReturnsError(t *testing.T) {
+	memFs := afero.NewMemMapFs()
+	require.NoError(t, memFs.MkdirAll("/src", 0755))
+	mkdirErr := errors.New("mkdir failed")
+	fs := &errMkdirAllFs{Fs: memFs, err: mkdirErr}
+	provider := NewProvider(fs, "/runs", func() (string, error) {
+		return "/src", nil
+	})
+
+	_, err := provider.Provision(context.Background(), url.URL{Scheme: "cwd"})
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, mkdirErr)
+}
+
+func TestProvider_Provision_WhenCopyFails_ThenCleansUpRunDir(t *testing.T) {
+	memFs := afero.NewMemMapFs()
+	require.NoError(t, memFs.MkdirAll("/src", 0755))
+	require.NoError(t, afero.WriteFile(memFs, "/src/file.txt", []byte("data"), 0644))
+	writeErr := errors.New("write failed")
+	fs := &errWriteFs{Fs: memFs, prefix: "/runs/", err: writeErr}
+	provider := NewProvider(fs, "/runs", func() (string, error) {
+		return "/src", nil
+	})
+
+	_, err := provider.Provision(context.Background(), url.URL{Scheme: "cwd"})
+
+	require.Error(t, err)
+	entries, readErr := afero.ReadDir(memFs, "/runs")
+	require.NoError(t, readErr)
+	assert.Empty(t, entries, "run directory should be cleaned up after copy failure")
+}
+
+func TestProvider_Provision_WhenSuccess_ThenCopiesFilesAndReturnsWorkDir(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll("/src/subdir", 0755))
+	require.NoError(t, afero.WriteFile(fs, "/src/file.txt", []byte("hello"), 0644))
+	require.NoError(t, afero.WriteFile(fs, "/src/subdir/nested.txt", []byte("nested"), 0644))
+	provider := NewProvider(fs, "/runs", func() (string, error) {
+		return "/src", nil
+	})
+
+	result, err := provider.Provision(context.Background(), url.URL{Scheme: "cwd"})
+
+	require.NoError(t, err)
+	require.NotEmpty(t, result.WorkDir)
+	require.NotNil(t, result.Cleanup)
+	content, readErr := afero.ReadFile(fs, result.WorkDir+"/file.txt")
+	require.NoError(t, readErr)
+	assert.Equal(t, []byte("hello"), content)
+	nestedContent, readNestedErr := afero.ReadFile(fs, result.WorkDir+"/subdir/nested.txt")
+	require.NoError(t, readNestedErr)
+	assert.Equal(t, []byte("nested"), nestedContent)
+}
+
+func TestProvider_Provision_WhenSuccess_ThenCleanupRemovesWorkDir(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll("/src", 0755))
+	require.NoError(t, afero.WriteFile(fs, "/src/file.txt", []byte("hello"), 0644))
+	provider := NewProvider(fs, "/runs", func() (string, error) {
+		return "/src", nil
+	})
+
+	result, err := provider.Provision(context.Background(), url.URL{Scheme: "cwd"})
+	require.NoError(t, err)
+	workDir := result.WorkDir
+
+	cleanupErr := result.Cleanup()
+
+	require.NoError(t, cleanupErr)
+	_, statErr := fs.Stat(workDir)
+	assert.True(t, os.IsNotExist(statErr), "work directory should not exist after cleanup")
+}


### PR DESCRIPTION
## Related issue

Closes #

## Summary

Adds a new `cwd://` workspace provider that automatically uses the current working directory as the workspace source, eliminating the need to specify an explicit path.

- `cwd://` provisions a fresh read-write copy of CWD on every execution (same isolation as `dir://`)
- Provisioned copy is cleaned up after execution completes
- `getwd` function is injectable for full unit test coverage without OS dependency
- Registered alongside existing `dir://`, `git+https://`, and `git+ssh://` providers

**Usage:** `--workspace cwd://` instead of `--workspace dir:///path/to/current/dir`