### PR TITLE
ci(orbiqd-orbiqd-briefkit): add HOL skill-publish validate workflow

### DIFF
--- a/.github/workflows/hol-skill-validate.yml
+++ b/.github/workflows/hol-skill-validate.yml
@@ -1,0 +1,28 @@
+name: HOL Skill Validate
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Validate Skill
+        uses: hashgraph-online/skill-publish@96e6eb1e52ba479d15067aef9dde83ca94afb06a
+        with:
+          mode: validate


### PR DESCRIPTION
I opened this as a small validate-only check for the skill metadata in the repo.

A couple of repo-specific details I checked first:
- BriefKit runs your local, subscription-based agent CLIs (no APIs or API keys) directly in your working directory or an
- BriefKit supports workflows where more than one LLM collaborates in the same workspace
- Note: You don't start briefkit-mcp manually. briefkit-ctl setup registers BriefKit as an MCP server using the

This adds one workflow for `.` and leaves the runtime code alone.
It only runs the schema and trust checks for the skill metadata in validate mode.

If you would rather place the workflow under a different filename or point it at a different skill directory, I can adjust the branch.