### PR TITLE
fix(runtime): increase scanner buffer to 10 MB to handle large agent responses

### DIFF
--- a/internal/pkg/runtime/claude/instance.go
+++ b/internal/pkg/runtime/claude/instance.go
@@ -185,7 +185,7 @@ func (instance *Instance) Wait(ctx context.Context) (briefkit.RuntimeResult, err
 
 func (instance *Instance) watchClaudeEvents(stdoutLog io.Writer) error {
 	scanner := bufio.NewScanner(io.TeeReader(instance.stdout, stdoutLog))
-	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+	scanner.Buffer(make([]byte, 10*1024*1024), 10*1024*1024)
 
 	for scanner.Scan() {
 		line := scanner.Text()

--- a/internal/pkg/runtime/codex/instance.go
+++ b/internal/pkg/runtime/codex/instance.go
@@ -192,7 +192,7 @@ func (instance *Instance) Wait(ctx context.Context) (briefkit.RuntimeResult, err
 
 func (instance *Instance) watchCodexEvents(stdoutLog io.Writer) error {
 	scanner := bufio.NewScanner(io.TeeReader(instance.stdout, stdoutLog))
-	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+	scanner.Buffer(make([]byte, 10*1024*1024), 10*1024*1024)
 
 	for scanner.Scan() {
 		line := scanner.Text()

--- a/internal/pkg/runtime/gemini/instance.go
+++ b/internal/pkg/runtime/gemini/instance.go
@@ -188,7 +188,7 @@ func (instance *Instance) watchGeminiEvents(stdoutLog io.Writer) error {
 	// We use a scanner to read line by line because Gemini CLI might output non-JSON text
 	// (e.g. "Loaded cached credentials.") mixed with JSON lines.
 	scanner := bufio.NewScanner(io.TeeReader(instance.stdout, stdoutLog))
-	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+	scanner.Buffer(make([]byte, 10*1024*1024), 10*1024*1024)
 
 	for scanner.Scan() {
 		line := scanner.Text()


### PR DESCRIPTION
## Related issue

Closes #

## Summary

The scanner buffer introduced in #62 was set to 1 MB, which proved insufficient for agents exploring large repositories (e.g. `cloudwego/eino`). Deep-analysis prompts cause codex to emit single JSON lines exceeding 1 MB, triggering `bufio.Scanner: token too long`.

Observed in two executions on 2026-05-12:
- `e521f2bc` (19:47) — stdout max line: 1 048 576 bytes (hit exact limit)
- `5089f1ed` (20:05) — stdout max line: 1 048 576 bytes (hit exact limit)

Increases the buffer from 1 MB to 10 MB across all three runtimes (claude, codex, gemini).